### PR TITLE
Revert "Set up subdomain for 2016 NDOCH site"

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-http://ndoch.openoakland.org


### PR DESCRIPTION
Accidentally added "http:" onto CNAME. Reverts openoakland/oaklandfutures#1
